### PR TITLE
#40 Set PNG transparent color to white

### DIFF
--- a/lib/Epub/Renderer/PNGHelper.cpp
+++ b/lib/Epub/Renderer/PNGHelper.cpp
@@ -70,8 +70,8 @@ void PNGHelper::draw_callback(PNGDRAW *draw)
   {
     // feed the watchdog
     vTaskDelay(1);
-    // get the rgb 565 pixel values
-    png.getLineAsRGB565(draw, tmp_rgb565_buffer, 0, 0);
+    // get the rgb 565 pixel values                 BKG is in form of 00BBGGRR
+    png.getLineAsRGB565(draw, tmp_rgb565_buffer, 0, 0x00FFFFFF);
     for (int x = 0; x < png.getWidth() * x_scale; x++)
     {
       uint8_t r, g, b;


### PR DESCRIPTION

![BAB87C5A-B25F-40FB-A5B3-4592FB80E118](https://user-images.githubusercontent.com/2692928/138821807-e361e21e-9278-4e8c-b297-e65af35ea809.jpeg)
PNG lib method: getLineAsRGB565

Has a parameter to set what default background you want. That seems to work great to convert transparent to white that is exactly what we need. I don't think we need to compare pixels since we are not really superimposing images on another things. For me delivers the expected result