### PR TITLE
Feature/46 index

### DIFF
--- a/lib/Epub/EpubList/Epub.cpp
+++ b/lib/Epub/EpubList/Epub.cpp
@@ -223,7 +223,8 @@ bool Epub::loadIndex()
   }
 
   auto navPoint = navMap->FirstChildElement("navPoint");
-   std::map<std::string, std::string> items;
+  
+  // Fills toc_index map
   while (navPoint)
   {
     // navPoint has also an id & playOrder element: navPoint->Attribute("id");
@@ -231,10 +232,25 @@ bool Epub::loadIndex()
     std::string title = navLabel->Value();
     auto content = navPoint->FirstChildElement("content");
     std::string href = content->Attribute("src");
+
+    toc_index.insert({title, href});
     ESP_LOGI(TAG, "title %s src %s", title.c_str(), href.c_str());
     navPoint = navPoint->NextSiblingElement("navPoint");
   }
+  // Test find key
+  //get_index_src("Cubierta");
   return true;
+}
+
+std::string Epub::get_index_src(std::string key) {
+    auto search = toc_index.find(key);
+    if (search != toc_index.end()) {
+        ESP_LOGI(TAG, "Found key %s result href: %s", search->first.c_str(), search->second.c_str());
+        return search->second;
+    } else {
+        ESP_LOGI(TAG, "key:%s not found in toc", search->first.c_str());
+        return "";
+    }
 }
 
 const std::string &Epub::get_title()

--- a/lib/Epub/EpubList/Epub.cpp
+++ b/lib/Epub/EpubList/Epub.cpp
@@ -184,7 +184,7 @@ bool Epub::loadIndex()
   // Update this so it's read from manifest v
   // Or alternatively reads an ncx file in OEBPS directory
   const char *tocFile = "OEBPS/toc.ncx";
-  
+
   char *meta_index = (char *)zip.read_file_to_memory(tocFile);
   if (!meta_index)
   {
@@ -207,14 +207,14 @@ bool Epub::loadIndex()
     return false;
   }
   printf("ncx in line:%d\n", ncx->GetLineNum());
-  
+
   auto docTitle = ncx->FirstChildElement("docTitle");
   if (!docTitle)
   {
     ESP_LOGE(TAG, "Could not find docTitle child in ncx");
     return false;
   }
-  
+
   auto navMap = ncx->FirstChildElement("navMap");
   if (!navMap)
   {
@@ -223,7 +223,7 @@ bool Epub::loadIndex()
   }
 
   auto navPoint = navMap->FirstChildElement("navPoint");
-  
+
   // Fills toc_index map
   while (navPoint)
   {
@@ -233,7 +233,7 @@ bool Epub::loadIndex()
     auto content = navPoint->FirstChildElement("content");
     std::string href = content->Attribute("src");
 
-    toc_index.insert({title, href});
+    toc_index.push_back(std::make_pair(title, href));
     ESP_LOGI(TAG, "title %s src %s", title.c_str(), href.c_str());
     navPoint = navPoint->NextSiblingElement("navPoint");
   }
@@ -242,15 +242,9 @@ bool Epub::loadIndex()
   return true;
 }
 
-std::string Epub::get_index_src(std::string key) {
-    auto search = toc_index.find(key);
-    if (search != toc_index.end()) {
-        ESP_LOGI(TAG, "Found key %s result href: %s", search->first.c_str(), search->second.c_str());
-        return search->second;
-    } else {
-        ESP_LOGI(TAG, "key:%s not found in toc", search->first.c_str());
-        return "";
-    }
+std::string Epub::get_index_src(int index)
+{
+  return toc_index[index].second;
 }
 
 const std::string &Epub::get_title()

--- a/lib/Epub/EpubList/Epub.cpp
+++ b/lib/Epub/EpubList/Epub.cpp
@@ -200,29 +200,40 @@ bool Epub::loadIndex()
     ESP_LOGE(TAG, "Error parsing toc %s", doc.ErrorIDToName(result));
     return false;
   }
-  auto ncx = doc.FirstChild();
+  auto ncx = doc.FirstChildElement("ncx");
   if (!ncx)
   {
     ESP_LOGE(TAG, "Could not find first child ncx in toc");
     return false;
   }
   printf("ncx in line:%d\n", ncx->GetLineNum());
+  
+  auto docTitle = ncx->FirstChildElement("docTitle");
+  if (!docTitle)
+  {
+    ESP_LOGE(TAG, "Could not find docTitle child in ncx");
+    return false;
+  }
+  
   auto navMap = ncx->FirstChildElement("navMap");
   if (!navMap)
   {
     ESP_LOGE(TAG, "Could not find navMap child in ncx");
     return false;
   }
-  /* auto navPoint = navMap->FirstChildElement("navPoint");
+
+  auto navPoint = navMap->FirstChildElement("navPoint");
    std::map<std::string, std::string> items;
   while (navPoint)
   {
-    std::string item_id = navPoint->Attribute("id");
+    // navPoint has also an id & playOrder element: navPoint->Attribute("id");
+    auto navLabel = navPoint->FirstChildElement("navLabel")->FirstChildElement("text")->FirstChild();
+    std::string title = navLabel->Value();
     auto content = navPoint->FirstChildElement("content");
     std::string href = content->Attribute("src");
-    printf("id %s src %s", item_id.c_str(), href.c_str());
+    ESP_LOGI(TAG, "title %s src %s", title.c_str(), href.c_str());
     navPoint = navPoint->NextSiblingElement("navPoint");
-  } */
+  }
   return true;
 }
 

--- a/lib/Epub/EpubList/Epub.cpp
+++ b/lib/Epub/EpubList/Epub.cpp
@@ -236,7 +236,7 @@ bool Epub::parse_toc_ncx_file(ZipFile &zip)
       href = href.substr(0, pos);
     }
     m_toc.push_back(EpubTocEntry(title, href, anchor, 0));
-    ESP_LOGI(TAG, "%s -> %s#%s", title.c_str(), href.c_str(), anchor.c_str());
+    // ESP_LOGI(TAG, "%s -> %s#%s", title.c_str(), href.c_str(), anchor.c_str());
     navPoint = navPoint->NextSiblingElement("navPoint");
   }
   return true;

--- a/lib/Epub/EpubList/Epub.cpp
+++ b/lib/Epub/EpubList/Epub.cpp
@@ -342,7 +342,6 @@ int Epub::get_spine_items_count()
 
 std::string &Epub::get_spine_item(int spine_index)
 {
-  ESP_LOGI(TAG, "get_spine_item(%d) %s", spine_index, m_spine[spine_index].second.c_str());
   return m_spine[spine_index].second;
 }
 
@@ -363,7 +362,6 @@ int Epub::get_spine_index_for_toc_index(int toc_index)
   // so we can find the spine index by looking for the href
   for (int i = 0; i < m_spine.size(); i++)
   {
-    ESP_LOGI(TAG, "get_spine_index_for_toc_index(%d) %s, %s", toc_index, m_spine[i].second.c_str(), m_toc[toc_index].href.c_str());
     if (m_spine[i].second == m_toc[toc_index].href)
     {
       return i;

--- a/lib/Epub/EpubList/Epub.cpp
+++ b/lib/Epub/EpubList/Epub.cpp
@@ -170,7 +170,7 @@ bool Epub::load()
     auto id = itemref->Attribute("idref");
     if (items.find(id) != items.end())
     {
-      printf("%s -> %s\n", id, items[id].c_str());
+      //printf("%s -> %s\n", id, items[id].c_str());
       m_spine.push_back(std::make_pair(id, items[id]));
     }
     itemref = itemref->NextSiblingElement("itemref");
@@ -361,12 +361,11 @@ std::string Epub::get_toc_filename() {
     // create a mapping from id to file name
     auto item = manifest->FirstChildElement("item");
     std::map<std::string, std::string> items;
-    std::string base_dir = "OEBPS/";
     std::string find_ncx = "ncx";
     while (item)
     {
       if (item->Attribute("id") == find_ncx) {
-        std::string href = base_dir + item->Attribute("href");
+        std::string href = m_base_path + item->Attribute("href");
         return href;
       }
       item = item->NextSiblingElement("item");

--- a/lib/Epub/EpubList/Epub.cpp
+++ b/lib/Epub/EpubList/Epub.cpp
@@ -224,7 +224,7 @@ bool Epub::parse_toc_ncx_file(ZipFile &zip)
     auto navLabel = navPoint->FirstChildElement("navLabel")->FirstChildElement("text")->FirstChild();
     std::string title = navLabel->Value();
     auto content = navPoint->FirstChildElement("content");
-    std::string href = content->Attribute("src");
+    std::string href = m_base_path + content->Attribute("src");
     // split the href on the # to get the href and the anchor
     size_t pos = href.find('#');
     std::string anchor = "";
@@ -363,11 +363,13 @@ int Epub::get_spine_index_for_toc_index(int toc_index)
   // so we can find the spine index by looking for the href
   for (int i = 0; i < m_spine.size(); i++)
   {
+    ESP_LOGI(TAG, "get_spine_index_for_toc_index(%d) %s, %s", toc_index, m_spine[i].second.c_str(), m_toc[toc_index].href.c_str());
     if (m_spine[i].second == m_toc[toc_index].href)
     {
       return i;
     }
   }
+  ESP_LOGI(TAG, "Section not found");
   // not found - default to the start of the book
   return 0;
 }

--- a/lib/Epub/EpubList/Epub.cpp
+++ b/lib/Epub/EpubList/Epub.cpp
@@ -200,7 +200,6 @@ bool Epub::parse_toc_ncx_file(ZipFile &zip)
     ESP_LOGE(TAG, "Could not find first child ncx in toc");
     return false;
   }
-  printf("ncx in line:%d\n", ncx->GetLineNum());
 
   auto docTitle = ncx->FirstChildElement("docTitle");
   if (!docTitle)

--- a/lib/Epub/EpubList/Epub.cpp
+++ b/lib/Epub/EpubList/Epub.cpp
@@ -177,7 +177,7 @@ bool Epub::load()
   return true;
 }
 
-// load in the meta data for the epub file
+// load in the TOC index data for the epub file (Chapters)
 bool Epub::loadIndex()
 {
   ZipFile zip(m_path.c_str());

--- a/lib/Epub/EpubList/Epub.cpp
+++ b/lib/Epub/EpubList/Epub.cpp
@@ -170,7 +170,8 @@ bool Epub::load()
     auto id = itemref->Attribute("idref");
     if (items.find(id) != items.end())
     {
-      m_spine.push_back(items[id]);
+      printf("%s -> %s\n", id, items[id].c_str());
+      m_spine.push_back(std::make_pair(id, items[id]));
     }
     itemref = itemref->NextSiblingElement("itemref");
   }
@@ -181,10 +182,10 @@ bool Epub::load()
 bool Epub::loadIndex()
 {
   ZipFile zip(m_path.c_str());
-  // Update this so it's read from manifest v
-  // Or alternatively reads an ncx file in OEBPS directory
-  ESP_LOGI(TAG, "toc path: %s\n", get_toc_filename().c_str());
+  
   const char *tocFile = get_toc_filename().c_str();
+  ESP_LOGI(TAG, "toc path: %s\n", tocFile);
+
   char *meta_index = (char *)zip.read_file_to_memory(tocFile);
   if (!meta_index)
   {
@@ -234,11 +235,10 @@ bool Epub::loadIndex()
     std::string href = content->Attribute("src");
 
     toc_index.push_back(std::make_pair(title, href));
-    ESP_LOGI(TAG, "title %s src %s", title.c_str(), href.c_str());
+    ESP_LOGI(TAG, "%s -> %s", title.c_str(), href.c_str());
     navPoint = navPoint->NextSiblingElement("navPoint");
   }
-  // Test find key
-  //get_index_src("Cubierta");
+  
   return true;
 }
 
@@ -322,7 +322,7 @@ uint8_t *Epub::get_item_contents(const std::string &item_href, size_t *size)
 
 std::string &Epub::get_spine_item(int spine_index)
 {
-  return m_spine[spine_index];
+  return m_spine[spine_index].second;
 }
 
 std::string Epub::get_toc_filename() {

--- a/lib/Epub/EpubList/Epub.h
+++ b/lib/Epub/EpubList/Epub.h
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <vector>
+#include <unordered_map>
 
 class ZipFile;
 
@@ -16,6 +17,9 @@ private:
   std::string m_path;
   // the spine of the EPUB file
   std::vector<std::string> m_spine;
+  // the index of chapters
+  std::unordered_map<std::string, std::string> toc_index;
+
   // the base path for items in the EPUB file
   std::string m_base_path;
 
@@ -27,7 +31,11 @@ public:
   ~Epub() {}
   std::string &get_base_path() { return m_base_path; }
   bool load();
+  // Fills toc_index map
   bool loadIndex();
+  // Finds the src value in the index
+  std::string get_index_src(std::string key);
+
   const std::string &get_path() const { return m_path; }
   const std::string &get_title();
   const std::string &get_cover_image_item();

--- a/lib/Epub/EpubList/Epub.h
+++ b/lib/Epub/EpubList/Epub.h
@@ -17,11 +17,10 @@ private:
   std::string m_path;
   // the path of the *.ncx index
   std::string toc_path;
-  // the spine of the EPUB file
-  std::vector<std::pair<std::string, std::string>> m_spine;
   // the base path for items in the EPUB file
   std::string m_base_path;
-
+  // the spine of the EPUB file
+  std::vector<std::pair<std::string, std::string>> m_spine;
   // find the path for the content.opf file
   bool find_content_opf_file(ZipFile &zip, std::string &content_opf_file);
   std::string get_toc_filename();
@@ -35,13 +34,18 @@ public:
   bool loadIndex();
   // Finds the src value in the index
   std::string get_index_src(int index);
+  int get_index_size();
 
   const std::string &get_path() const { return m_path; }
   const std::string &get_title();
   const std::string &get_cover_image_item();
   uint8_t *get_item_contents(const std::string &item_href, size_t *size = nullptr);
   std::string &get_spine_item(int spine_index);
+  int get_spine_item_id(std::string spine_key);
   int get_spine_items_count();
+
+  // is public since we will use it from EpubIndex
+  std::vector<std::string> split(std::string to_split, std::string delimiter);
 
   // the index of chapters
   std::vector<std::pair<std::string, std::string>> toc_index;

--- a/lib/Epub/EpubList/Epub.h
+++ b/lib/Epub/EpubList/Epub.h
@@ -15,6 +15,8 @@ private:
   std::string m_cover_image_item;
   // where is the EPUBfile?
   std::string m_path;
+  // the path of the *.ncx index
+  std::string toc_path;
   // the spine of the EPUB file
   std::vector<std::string> m_spine;
   // the base path for items in the EPUB file
@@ -22,6 +24,7 @@ private:
 
   // find the path for the content.opf file
   bool find_content_opf_file(ZipFile &zip, std::string &content_opf_file);
+  std::string get_toc_filename();
 
 public:
   Epub(const std::string &path);

--- a/lib/Epub/EpubList/Epub.h
+++ b/lib/Epub/EpubList/Epub.h
@@ -18,7 +18,7 @@ private:
   // the path of the *.ncx index
   std::string toc_path;
   // the spine of the EPUB file
-  std::vector<std::string> m_spine;
+  std::vector<std::pair<std::string, std::string>> m_spine;
   // the base path for items in the EPUB file
   std::string m_base_path;
 

--- a/lib/Epub/EpubList/Epub.h
+++ b/lib/Epub/EpubList/Epub.h
@@ -31,7 +31,7 @@ public:
   // Fills toc_index map
   bool loadIndex();
   // Finds the src value in the index
-  std::string get_index_src(std::string key);
+  std::string get_index_src(int index);
 
   const std::string &get_path() const { return m_path; }
   const std::string &get_title();
@@ -41,5 +41,5 @@ public:
   int get_spine_items_count();
 
   // the index of chapters
-  std::unordered_map<std::string, std::string> toc_index;
+  std::vector<std::pair<std::string, std::string>> toc_index;
 };

--- a/lib/Epub/EpubList/Epub.h
+++ b/lib/Epub/EpubList/Epub.h
@@ -6,6 +6,16 @@
 
 class ZipFile;
 
+class EpubTocEntry
+{
+public:
+  std::string title;
+  std::string href;
+  std::string anchor;
+  int level;
+  EpubTocEntry(std::string title, std::string href, std::string anchor, int level) : title(title), href(href), anchor(anchor), level(level) {}
+};
+
 class Epub
 {
 private:
@@ -13,40 +23,38 @@ private:
   std::string m_title;
   // the cover image
   std::string m_cover_image_item;
+  // the ncx file
+  std::string m_toc_ncx_item;
   // where is the EPUBfile?
   std::string m_path;
-  // the path of the *.ncx index
-  std::string toc_path;
-  // the base path for items in the EPUB file
-  std::string m_base_path;
   // the spine of the EPUB file
   std::vector<std::pair<std::string, std::string>> m_spine;
+  // the toc of the EPUB file
+  std::vector<EpubTocEntry> m_toc;
+  // the base path for items in the EPUB file
+  std::string m_base_path;
   // find the path for the content.opf file
   bool find_content_opf_file(ZipFile &zip, std::string &content_opf_file);
-  std::string get_toc_filename();
+  bool parse_content_opf(ZipFile &zip, std::string &content_opf_file);
+  bool parse_toc_ncx_file(ZipFile &zip);
 
 public:
   Epub(const std::string &path);
   ~Epub() {}
   std::string &get_base_path() { return m_base_path; }
   bool load();
-  // Fills toc_index map
-  bool loadIndex();
-  // Finds the src value in the index
-  std::string get_index_src(int index);
-  int get_index_size();
 
   const std::string &get_path() const { return m_path; }
   const std::string &get_title();
   const std::string &get_cover_image_item();
   uint8_t *get_item_contents(const std::string &item_href, size_t *size = nullptr);
+
   std::string &get_spine_item(int spine_index);
   int get_spine_item_id(std::string spine_key);
   int get_spine_items_count();
 
-  // is public since we will use it from EpubIndex
-  std::vector<std::string> split(std::string to_split, std::string delimiter);
-
-  // the index of chapters
-  std::vector<std::pair<std::string, std::string>> toc_index;
+  EpubTocEntry &get_toc_item(int toc_index);
+  int get_toc_items_count();
+  // work out the section index for a toc index
+  int get_spine_index_for_toc_index(int toc_index);
 };

--- a/lib/Epub/EpubList/Epub.h
+++ b/lib/Epub/EpubList/Epub.h
@@ -27,6 +27,7 @@ public:
   ~Epub() {}
   std::string &get_base_path() { return m_base_path; }
   bool load();
+  bool loadIndex();
   const std::string &get_path() const { return m_path; }
   const std::string &get_title();
   const std::string &get_cover_image_item();

--- a/lib/Epub/EpubList/Epub.h
+++ b/lib/Epub/EpubList/Epub.h
@@ -17,9 +17,6 @@ private:
   std::string m_path;
   // the spine of the EPUB file
   std::vector<std::string> m_spine;
-  // the index of chapters
-  std::unordered_map<std::string, std::string> toc_index;
-
   // the base path for items in the EPUB file
   std::string m_base_path;
 
@@ -42,4 +39,7 @@ public:
   uint8_t *get_item_contents(const std::string &item_href, size_t *size = nullptr);
   std::string &get_spine_item(int spine_index);
   int get_spine_items_count();
+
+  // the index of chapters
+  std::unordered_map<std::string, std::string> toc_index;
 };

--- a/lib/Epub/EpubList/EpubIndex.cpp
+++ b/lib/Epub/EpubList/EpubIndex.cpp
@@ -61,7 +61,6 @@ void EpubIndex::render()
   if (current_page != state.previous_rendered_page || m_needs_redraw)
   {
     m_needs_redraw = false;
-    renderer->show_busy();
     renderer->clear_screen();
     state.previous_selected_item = -1;
     // trigger a redraw of the items

--- a/lib/Epub/EpubList/EpubIndex.cpp
+++ b/lib/Epub/EpubList/EpubIndex.cpp
@@ -105,6 +105,7 @@ void EpubIndex::render()
     }
     ypos += cell_height;
   }
+  state.previous_selected_item = state.selected_item;
   state.previous_rendered_page = current_page;
 }
 

--- a/lib/Epub/EpubList/EpubIndex.cpp
+++ b/lib/Epub/EpubList/EpubIndex.cpp
@@ -1,0 +1,39 @@
+#include "EpubIndex.h"
+static const char *TAG = "PUBINDEX";
+
+#define PADDING 20
+#define EPUBS_PER_PAGE 5
+
+void EpubIndex::next()
+{
+  //state->selected_item = (state->selected_item + 1) % state->num_epubs;
+}
+
+void EpubIndex::prev()
+{
+  // Pending implementation
+}
+
+bool EpubIndex::load()
+{
+  ESP_LOGI(TAG, "load");
+  // do we need to load the epub?
+  if (!epub || epub->get_path() != state.path)
+  {
+    renderer->show_busy();
+    delete epub;
+    
+    epub = new Epub(state.path);
+    if (epub->loadIndex())
+    {
+      ESP_LOGI(TAG, "Epub loaded");
+      return false;
+    }
+  }
+  return true;
+}
+
+void EpubIndex::render()
+{
+  ESP_LOGD(TAG, "Rendering EPUB index (Pending)");
+}

--- a/lib/Epub/EpubList/EpubIndex.cpp
+++ b/lib/Epub/EpubList/EpubIndex.cpp
@@ -19,7 +19,7 @@ bool EpubIndex::load()
   {
     renderer->show_busy();
     delete epub;
-    
+
     epub = new Epub(state.path);
     if (epub->loadIndex())
     {
@@ -37,25 +37,24 @@ void EpubIndex::render()
   renderer->clear_screen();
   int toc_size = (epub->toc_index.size()) ? epub->toc_index.size() : 1;
   int cell_height = renderer->get_page_height() / toc_size;
-  int text_ypos = 10;
-  int y_offset = 20;
-  int idx = 0;
-  
-  printf("TOC index size:%d\n", epub->toc_index.size());
-  TextBlock *index_block = new TextBlock(LEFT_ALIGN);
 
-  for(auto iter = epub->toc_index.begin(); iter != epub->toc_index.end(); ++iter){
+  printf("TOC index size:%u\n", epub->toc_index.size());
+
+  for (auto iter = epub->toc_index.begin(); iter != epub->toc_index.end(); ++iter)
+  {
+    // temporary index block for text rendering
+    TextBlock *index_block = new TextBlock(LEFT_ALIGN);
     // Correctly printing each index item
     index_block->add_span(iter->first.c_str(), false, false);
     index_block->layout(renderer, epub, renderer->get_page_width());
-    printf("%d %s\n", idx, iter->first.c_str());
-
-    index_block->render(renderer, idx, 10, text_ypos + y_offset);
+    // draw each line of the index block making sure we don't run over the cell
+    for (int i = 0; i < index_block->line_breaks.size(); i++)
+    {
+      index_block->render(renderer, i, 0, y_offset);
+      y_offset += renderer->get_line_height();
+    }
     y_offset += renderer->get_line_height();
-    idx++;
-    // Chris I don't understand why printing more than 2 it fails:
-    if (idx == 2) break;
+    // clean up the temporary index block
+    delete index_block;
   }
-  delete index_block;
-  
 }

--- a/lib/Epub/EpubList/EpubIndex.cpp
+++ b/lib/Epub/EpubList/EpubIndex.cpp
@@ -1,9 +1,6 @@
 #include "EpubIndex.h"
 static const char *TAG = "PUBINDEX";
 
-#define PADDING 20
-#define EPUBS_PER_PAGE 5
-
 void EpubIndex::next()
 {
   //state->selected_item = (state->selected_item + 1) % state->num_epubs;
@@ -26,14 +23,36 @@ bool EpubIndex::load()
     epub = new Epub(state.path);
     if (epub->loadIndex())
     {
-      ESP_LOGI(TAG, "Epub loaded");
+      ESP_LOGI(TAG, "Epub index loaded");
       return false;
     }
   }
+  render();
   return true;
 }
 
 void EpubIndex::render()
 {
   ESP_LOGD(TAG, "Rendering EPUB index (Pending)");
+  renderer->clear_screen();
+  int toc_size = (epub->toc_index.size()) ? epub->toc_index.size() : 1;
+  int cell_height = renderer->get_page_height() / toc_size;
+  int text_height = cell_height - 20 * 2;
+  int i = 0;
+  int text_ypos = 10;
+  int y_offset = 20;
+  
+  printf("TOC index size:%d\n", epub->toc_index.size());
+  TextBlock *index_block = new TextBlock(LEFT_ALIGN);
+
+  for(auto iter = epub->toc_index.begin(); iter != epub->toc_index.end(); ++iter){
+    // Correctly printing each index item
+    printf("%s\n", iter->first.c_str());
+    index_block->add_span(iter->first.c_str(), false, false);
+    // Hangs everything :(  Chris need some help!
+    //index_block->render(renderer, i, 10, text_ypos + y_offset);
+    y_offset += renderer->get_line_height();
+    i++;
+  }
+
 }

--- a/lib/Epub/EpubList/EpubIndex.cpp
+++ b/lib/Epub/EpubList/EpubIndex.cpp
@@ -1,6 +1,5 @@
 #include "EpubIndex.h"
-// Padding should be dynamic since they could have more than one line
-#define PADDING 66
+
 static const char *TAG = "PUBINDEX";
 
 void EpubIndex::next()
@@ -35,7 +34,7 @@ bool EpubIndex::load()
 
 void EpubIndex::render()
 {
-  ESP_LOGD(TAG, "Rendering EPUB index (Pending)");
+  ESP_LOGD(TAG, "Rendering EPUB index");
   renderer->clear_screen();
   int toc_size = (epub->toc_index.size()) ? epub->toc_index.size() : 1;
   int cell_height = renderer->get_page_height() / toc_size;

--- a/lib/Epub/EpubList/EpubIndex.cpp
+++ b/lib/Epub/EpubList/EpubIndex.cpp
@@ -6,12 +6,22 @@ static const char *TAG = "PUBINDEX";
 
 void EpubIndex::next()
 {
-  selected_item = (selected_item + 1) % toc_count;
+  // must be loaded as we need the information from the epub
+  if (!epub)
+  {
+    load();
+  }
+  state.selected_item = (state.selected_item + 1) % epub->get_toc_items_count();
 }
 
 void EpubIndex::prev()
 {
-  selected_item = (selected_item - 1 + toc_count) % toc_count;
+  // must be loaded as we need the information from the epub
+  if (!epub)
+  {
+    load();
+  }
+  state.selected_item = (state.selected_item - 1 + epub->get_toc_items_count()) % epub->get_toc_items_count();
 }
 
 bool EpubIndex::load()
@@ -30,7 +40,6 @@ bool EpubIndex::load()
       return false;
     }
   }
-  render();
   return true;
 }
 
@@ -87,6 +96,7 @@ void EpubIndex::render()
     }
     ypos += cell_height;
   }
+  state.previous_rendered_page = state.current_page;
 }
 
 uint16_t EpubIndex::get_selected_toc()

--- a/lib/Epub/EpubList/EpubIndex.cpp
+++ b/lib/Epub/EpubList/EpubIndex.cpp
@@ -79,3 +79,7 @@ void EpubIndex::render()
     iter_count++;
   }
 }
+
+uint16_t EpubIndex::get_selected_toc() {
+  return selected_item;
+}

--- a/lib/Epub/EpubList/EpubIndex.cpp
+++ b/lib/Epub/EpubList/EpubIndex.cpp
@@ -96,7 +96,7 @@ void EpubIndex::render()
     }
     ypos += cell_height;
   }
-  state.previous_rendered_page = state.current_page;
+  state.previous_rendered_page = current_page;
 }
 
 uint16_t EpubIndex::get_selected_toc()

--- a/lib/Epub/EpubList/EpubIndex.cpp
+++ b/lib/Epub/EpubList/EpubIndex.cpp
@@ -37,22 +37,25 @@ void EpubIndex::render()
   renderer->clear_screen();
   int toc_size = (epub->toc_index.size()) ? epub->toc_index.size() : 1;
   int cell_height = renderer->get_page_height() / toc_size;
-  int text_height = cell_height - 20 * 2;
-  int i = 0;
   int text_ypos = 10;
   int y_offset = 20;
+  int idx = 0;
   
   printf("TOC index size:%d\n", epub->toc_index.size());
   TextBlock *index_block = new TextBlock(LEFT_ALIGN);
 
   for(auto iter = epub->toc_index.begin(); iter != epub->toc_index.end(); ++iter){
     // Correctly printing each index item
-    printf("%s\n", iter->first.c_str());
     index_block->add_span(iter->first.c_str(), false, false);
-    // Hangs everything :(  Chris need some help!
-    //index_block->render(renderer, i, 10, text_ypos + y_offset);
-    y_offset += renderer->get_line_height();
-    i++;
-  }
+    index_block->layout(renderer, epub, renderer->get_page_width());
+    printf("%d %s\n", idx, iter->first.c_str());
 
+    index_block->render(renderer, idx, 10, text_ypos + y_offset);
+    y_offset += renderer->get_line_height();
+    idx++;
+    // Chris I don't understand why printing more than 2 it fails:
+    if (idx == 2) break;
+  }
+  delete index_block;
+  
 }

--- a/lib/Epub/EpubList/EpubIndex.cpp
+++ b/lib/Epub/EpubList/EpubIndex.cpp
@@ -90,17 +90,17 @@ void EpubIndex::render()
     // clear the selection box around the previous selected item
     if (state.previous_selected_item == i)
     {
-      for (int i = 0; i < 3; i++)
+      for (int line = 0; line < 3; line++)
       {
-        renderer->draw_rect(i, ypos + PADDING / 2 + i, renderer->get_page_width() - 2 * i, cell_height - PADDING - 2 * i, 255);
+        renderer->draw_rect(line, ypos + PADDING / 2 + line, renderer->get_page_width() - 2 * line, cell_height - PADDING - 2 * line, 255);
       }
     }
     // draw the selection box around the current selection
     if (state.selected_item == i)
     {
-      for (int i = 0; i < 3; i++)
+      for (int line = 0; line < 3; line++)
       {
-        renderer->draw_rect(i, ypos + PADDING / 2 + i, renderer->get_page_width() - 2 * i, cell_height - PADDING - 2 * i, 0);
+        renderer->draw_rect(line, ypos + PADDING / 2 + line, renderer->get_page_width() - 2 * line, cell_height - PADDING - 2 * line, 0);
       }
     }
     ypos += cell_height;

--- a/lib/Epub/EpubList/EpubIndex.cpp
+++ b/lib/Epub/EpubList/EpubIndex.cpp
@@ -72,20 +72,24 @@ void EpubIndex::render()
     // do we need to draw a new page of items?
     if (current_page != state.previous_rendered_page)
     {
-
       // format the text using a text block
-      TextBlock *index_block = new TextBlock(LEFT_ALIGN);
-      index_block->add_span(epub->get_toc_item(i).title.c_str(), false, false);
-      index_block->layout(renderer, epub, renderer->get_page_width());
+      TextBlock *title_block = new TextBlock(LEFT_ALIGN);
+      title_block->add_span(epub->get_toc_item(i).title.c_str(), false, false);
+      title_block->layout(renderer, epub, renderer->get_page_width());
+      // work out the height of the title
+      int text_height = cell_height - PADDING * 2;
+      int title_height = title_block->line_breaks.size() * renderer->get_line_height();
+      // center the title in the cell
+      int y_offset = title_height < text_height ? (text_height - title_height) / 2 : 0;
       // draw each line of the index block making sure we don't run over the cell
       int height = 0;
-      for (int i = 0; i < index_block->line_breaks.size() && height < cell_height; i++)
+      for (int i = 0; i < title_block->line_breaks.size() && height < text_height; i++)
       {
-        index_block->render(renderer, i, 0, ypos + height);
+        title_block->render(renderer, i, 0, ypos + height + y_offset);
         height += renderer->get_line_height();
       }
       // clean up the temporary index block
-      delete index_block;
+      delete title_block;
     }
     // clear the selection box around the previous selected item
     if (state.previous_selected_item == i)

--- a/lib/Epub/EpubList/EpubIndex.cpp
+++ b/lib/Epub/EpubList/EpubIndex.cpp
@@ -1,6 +1,8 @@
 #include "EpubIndex.h"
 
 static const char *TAG = "PUBINDEX";
+#define PADDING 20
+#define ITEMS_PER_PAGE 10
 
 void EpubIndex::next()
 {
@@ -15,16 +17,14 @@ void EpubIndex::prev()
 bool EpubIndex::load()
 {
   ESP_LOGI(TAG, "load");
-  
-  if (!epub || epub->get_path() != state.path)
+
+  if (!epub || epub->get_path() != selected_epub.path)
   {
     renderer->show_busy();
     delete epub;
 
-    epub = new Epub(state.path);
-    // Need to load the Spine
-    epub->load();
-    if (epub->loadIndex())
+    epub = new Epub(selected_epub.path);
+    if (epub->load())
     {
       ESP_LOGI(TAG, "Epub index loaded");
       return false;
@@ -37,64 +37,59 @@ bool EpubIndex::load()
 void EpubIndex::render()
 {
   ESP_LOGD(TAG, "Rendering EPUB index");
-  renderer->clear_screen();
-  int toc_size = (epub->toc_index.size()) ? epub->toc_index.size() : 1;
-  int cell_height = renderer->get_page_height() / toc_size;
-  int y_offset = 10;
-  toc_count = epub->toc_index.size();
-  int iter_count = 0;
-  int ypos = 10;
-  uint8_t xpos = 20;
-
-  for (auto iter = epub->toc_index.begin(); iter != epub->toc_index.end(); ++iter)
+  // what page are we on?
+  int current_page = state.selected_item / ITEMS_PER_PAGE;
+  // show five items per page
+  int cell_height = renderer->get_page_height() / ITEMS_PER_PAGE;
+  int start_index = current_page * ITEMS_PER_PAGE;
+  int ypos = 0;
+  // starting a fresh page or rendering from scratch?
+  ESP_LOGI(TAG, "Current page is %d, previous page %d, redraw=%d", current_page, state.previous_rendered_page, m_needs_redraw);
+  if (current_page != state.previous_rendered_page || m_needs_redraw)
   {
-    // temporary index block for text rendering
+    m_needs_redraw = false;
+    renderer->show_busy();
+    renderer->clear_screen();
+    state.previous_selected_item = -1;
+    // trigger a redraw of the items
+    state.previous_rendered_page = -1;
+  }
+  for (int i = start_index; i < start_index + ITEMS_PER_PAGE && i < epub->get_toc_items_count(); i++)
+  {
+    // format the text using a text block
     TextBlock *index_block = new TextBlock(LEFT_ALIGN);
-    // Correctly printing each index item
-    index_block->add_span(iter->first.c_str(), false, false);
+    index_block->add_span(epub->get_toc_item(i).title.c_str(), false, false);
     index_block->layout(renderer, epub, renderer->get_page_width());
     // draw each line of the index block making sure we don't run over the cell
-    for (int i = 0; i < index_block->line_breaks.size(); i++)
+    int height = 0;
+    for (int i = 0; i < index_block->line_breaks.size() && height < cell_height; i++)
     {
-      index_block->render(renderer, i, xpos, y_offset);
-      y_offset += renderer->get_line_height();
+      index_block->render(renderer, i, 0, ypos + height);
+      height += renderer->get_line_height();
     }
-    y_offset += renderer->get_line_height();
     // clean up the temporary index block
     delete index_block;
-
     // clear the selection box around the previous selected item
-    if (previous_selected_item == iter_count)
+    if (state.previous_selected_item == i)
     {
-      for (int i = 0; i < 3; i++) {
-        renderer->draw_rect(i, ypos+i, renderer->get_page_width(), 50, 255);
+      for (int i = 0; i < 3; i++)
+      {
+        renderer->draw_rect(i, ypos + PADDING / 2 + i, renderer->get_page_width() - 2 * i, cell_height - PADDING - 2 * i, 255);
       }
     }
     // draw the selection box around the current selection
-    if (selected_item == iter_count)
+    if (state.selected_item == i)
     {
-      for (int i = 0; i < 3; i++) {
-        renderer->draw_rect(i, ypos+i, renderer->get_page_width(), 50, 0);
+      for (int i = 0; i < 3; i++)
+      {
+        renderer->draw_rect(i, ypos + PADDING / 2 + i, renderer->get_page_width() - 2 * i, cell_height - PADDING - 2 * i, 0);
       }
     }
-    ypos += cell_height*1.25;
-    iter_count++;
+    ypos += cell_height;
   }
 }
 
-uint16_t EpubIndex::get_selected_toc() {
-  // should retrieve the tod ID and return the Spine ID
-  std::string toc_key = epub->get_index_src(selected_item);
-  std::vector<std::string> get_xhtml = epub->split(toc_key, "/");
-  std::vector<std::string> xhtml = epub->split(get_xhtml.back(), "#");
-  std::string clean_xhtml;
-  if (xhtml.size()) {
-    // We could find an anchor
-    clean_xhtml = xhtml.front();
-  } else {
-    clean_xhtml = get_xhtml.back();
-  }
-  printf("TOC key for id %d returns xhtml: %s\n\n", selected_item, clean_xhtml.c_str());
-  // Find this XHTML href in the Spine
-  return epub->get_spine_item_id(clean_xhtml);
+uint16_t EpubIndex::get_selected_toc()
+{
+  return epub->get_spine_index_for_toc_index(state.selected_item);
 }

--- a/lib/Epub/EpubList/EpubIndex.cpp
+++ b/lib/Epub/EpubList/EpubIndex.cpp
@@ -22,6 +22,8 @@ bool EpubIndex::load()
     delete epub;
 
     epub = new Epub(state.path);
+    // Need to load the Spine
+    epub->load();
     if (epub->loadIndex())
     {
       ESP_LOGI(TAG, "Epub index loaded");
@@ -81,5 +83,18 @@ void EpubIndex::render()
 }
 
 uint16_t EpubIndex::get_selected_toc() {
-  return selected_item;
+  // should retrieve the tod ID and return the Spine ID
+  std::string toc_key = epub->get_index_src(selected_item);
+  std::vector<std::string> get_xhtml = epub->split(toc_key, "/");
+  std::vector<std::string> xhtml = epub->split(get_xhtml.back(), "#");
+  std::string clean_xhtml;
+  if (xhtml.size()) {
+    // We could find an anchor
+    clean_xhtml = xhtml.front();
+  } else {
+    clean_xhtml = get_xhtml.back();
+  }
+  printf("TOC key for id %d returns xhtml: %s\n\n", selected_item, clean_xhtml.c_str());
+  // Find this XHTML href in the Spine
+  return epub->get_spine_item_id(clean_xhtml);
 }

--- a/lib/Epub/EpubList/EpubIndex.h
+++ b/lib/Epub/EpubList/EpubIndex.h
@@ -28,6 +28,9 @@ private:
   Renderer *renderer;
   Epub *epub = nullptr;
   EpubListItem &state;
+  int selected_item = 0;
+  int previous_selected_item = -1;
+  int toc_count = 0;
 
 public:
   EpubIndex(EpubListItem &state, Renderer *renderer) : renderer(renderer), state(state){};

--- a/lib/Epub/EpubList/EpubIndex.h
+++ b/lib/Epub/EpubList/EpubIndex.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <vector>
+#ifndef UNIT_TEST
+#include <esp_log.h>
+#else
+#define vTaskDelay(t)
+#define ESP_LOGE(args...)
+#define ESP_LOGI(args...)
+#define ESP_LOGD(args...)
+#endif
+#include <sys/types.h>
+#include <dirent.h>
+#include <string.h>
+#include <algorithm>
+
+#include "Epub.h"
+#include "Renderer/Renderer.h"
+#include "../RubbishHtmlParser/blocks/TextBlock.h"
+#include "../RubbishHtmlParser/htmlEntities.h"
+#include "./State.h"
+
+class Epub;
+class Renderer;
+
+class EpubIndex
+{
+private:
+  Renderer *renderer;
+  Epub *epub = nullptr;
+  EpubListItem &state;
+  bool m_needs_redraw = false;
+
+public:
+  EpubIndex(EpubListItem &state, Renderer *renderer) : renderer(renderer), state(state){};
+  ~EpubIndex() {}
+  bool load();
+  void next();
+  void prev();
+  void render();
+};

--- a/lib/Epub/EpubList/EpubIndex.h
+++ b/lib/Epub/EpubList/EpubIndex.h
@@ -17,7 +17,6 @@
 #include "Epub.h"
 #include "Renderer/Renderer.h"
 #include "../RubbishHtmlParser/blocks/TextBlock.h"
-#include "../RubbishHtmlParser/htmlEntities.h"
 #include "./State.h"
 
 class Epub;
@@ -29,7 +28,6 @@ private:
   Renderer *renderer;
   Epub *epub = nullptr;
   EpubListItem &state;
-  bool m_needs_redraw = false;
 
 public:
   EpubIndex(EpubListItem &state, Renderer *renderer) : renderer(renderer), state(state){};

--- a/lib/Epub/EpubList/EpubIndex.h
+++ b/lib/Epub/EpubList/EpubIndex.h
@@ -29,11 +29,6 @@ private:
   Epub *epub = nullptr;
   EpubListItem &selected_epub;
   EpubIndexState &state;
-  int selected_item = 0;
-  int previous_selected_item = -1;
-  int toc_count = 0;
-  uint8_t toc_page = 0;
-  uint8_t toc_page_total = 0;
   bool m_needs_redraw = false;
 
 public:

--- a/lib/Epub/EpubList/EpubIndex.h
+++ b/lib/Epub/EpubList/EpubIndex.h
@@ -27,19 +27,22 @@ class EpubIndex
 private:
   Renderer *renderer;
   Epub *epub = nullptr;
-  EpubListItem &state;
+  EpubListItem &selected_epub;
+  EpubIndexState &state;
   int selected_item = 0;
   int previous_selected_item = -1;
   int toc_count = 0;
   uint8_t toc_page = 0;
   uint8_t toc_page_total = 0;
+  bool m_needs_redraw = false;
 
 public:
-  EpubIndex(EpubListItem &state, Renderer *renderer) : renderer(renderer), state(state){};
+  EpubIndex(EpubListItem &selected_epub, EpubIndexState &state, Renderer *renderer) : renderer(renderer), selected_epub(selected_epub), state(state){};
   ~EpubIndex() {}
   bool load();
   void next();
   void prev();
   void render();
+  void set_needs_redraw() { m_needs_redraw = true; }
   uint16_t get_selected_toc();
 };

--- a/lib/Epub/EpubList/EpubIndex.h
+++ b/lib/Epub/EpubList/EpubIndex.h
@@ -31,6 +31,8 @@ private:
   int selected_item = 0;
   int previous_selected_item = -1;
   int toc_count = 0;
+  uint8_t toc_page = 0;
+  uint8_t toc_page_total = 0;
 
 public:
   EpubIndex(EpubListItem &state, Renderer *renderer) : renderer(renderer), state(state){};

--- a/lib/Epub/EpubList/EpubIndex.h
+++ b/lib/Epub/EpubList/EpubIndex.h
@@ -41,4 +41,5 @@ public:
   void next();
   void prev();
   void render();
+  uint16_t get_selected_toc();
 };

--- a/lib/Epub/EpubList/EpubList.cpp
+++ b/lib/Epub/EpubList/EpubList.cpp
@@ -23,26 +23,26 @@ static const char *TAG = "PUBLIST";
 
 void EpubList::next()
 {
-  state->selected_item = (state->selected_item + 1) % state->num_epubs;
+  state.selected_item = (state.selected_item + 1) % state.num_epubs;
 }
 
 void EpubList::prev()
 {
-  state->selected_item = (state->selected_item - 1 + state->num_epubs) % state->num_epubs;
+  state.selected_item = (state.selected_item - 1 + state.num_epubs) % state.num_epubs;
 }
 
 bool EpubList::load(const char *path)
 {
-  if (state->is_loaded)
+  if (state.is_loaded)
   {
     ESP_LOGI(TAG, "Already loaded books");
     return true;
   }
   renderer->show_busy();
   // trigger a proper redraw
-  state->previous_rendered_page = -1;
+  state.previous_rendered_page = -1;
   // read in the list of epubs
-  state->num_epubs = 0;
+  state.num_epubs = 0;
   DIR *dir;
   struct dirent *ent;
   if ((dir = opendir(path)) != NULL)
@@ -64,10 +64,10 @@ bool EpubList::load(const char *path)
       Epub *epub = new Epub(std::string("/fs/") + ent->d_name);
       if (epub->load())
       {
-        strncpy(state->epub_list[state->num_epubs].path, epub->get_path().c_str(), MAX_PATH_SIZE);
-        strncpy(state->epub_list[state->num_epubs].title, replace_html_entities(epub->get_title()).c_str(), MAX_TITLE_SIZE);
-        state->num_epubs++;
-        if (state->num_epubs == MAX_EPUB_LIST_SIZE)
+        strncpy(state.epub_list[state.num_epubs].path, epub->get_path().c_str(), MAX_PATH_SIZE);
+        strncpy(state.epub_list[state.num_epubs].title, replace_html_entities(epub->get_title()).c_str(), MAX_TITLE_SIZE);
+        state.num_epubs++;
+        if (state.num_epubs == MAX_EPUB_LIST_SIZE)
         {
           ESP_LOGE(TAG, "Too many epubs, max is %d", MAX_EPUB_LIST_SIZE);
           break;
@@ -81,8 +81,8 @@ bool EpubList::load(const char *path)
     }
     closedir(dir);
     std::sort(
-        state->epub_list,
-        state->epub_list + state->num_epubs,
+        state.epub_list,
+        state.epub_list + state.num_epubs,
         [](const EpubListItem &a, const EpubListItem &b)
         {
           return strcmp(a.title, b.title) < 0;
@@ -96,13 +96,13 @@ bool EpubList::load(const char *path)
     return false;
   }
   // sanity check our state
-  if (state->selected_item >= state->num_epubs)
+  if (state.selected_item >= state.num_epubs)
   {
-    state->selected_item = 0;
-    state->previous_rendered_page = -1;
-    state->previous_selected_item = -1;
+    state.selected_item = 0;
+    state.previous_rendered_page = -1;
+    state.previous_selected_item = -1;
   }
-  state->is_loaded = true;
+  state.is_loaded = true;
   return true;
 }
 
@@ -110,30 +110,30 @@ void EpubList::render()
 {
   ESP_LOGD(TAG, "Rendering EPUB list");
   // what page are we on?
-  int current_page = state->selected_item / EPUBS_PER_PAGE;
+  int current_page = state.selected_item / EPUBS_PER_PAGE;
   // draw a page of epubs
   int cell_height = renderer->get_page_height() / EPUBS_PER_PAGE;
   ESP_LOGD(TAG, "Cell height is %d", cell_height);
   int start_index = current_page * EPUBS_PER_PAGE;
   int ypos = 0;
   // starting a fresh page or rendering from scratch?
-  ESP_LOGI(TAG, "Current page is %d, previous page %d, redraw=%d", current_page, state->previous_rendered_page, m_needs_redraw);
-  if (current_page != state->previous_rendered_page || m_needs_redraw)
+  ESP_LOGI(TAG, "Current page is %d, previous page %d, redraw=%d", current_page, state.previous_rendered_page, m_needs_redraw);
+  if (current_page != state.previous_rendered_page || m_needs_redraw)
   {
     m_needs_redraw = false;
     renderer->show_busy();
     renderer->clear_screen();
-    state->previous_selected_item = -1;
+    state.previous_selected_item = -1;
     // trigger a redraw of the items
-    state->previous_rendered_page = -1;
+    state.previous_rendered_page = -1;
   }
-  for (int i = start_index; i < start_index + EPUBS_PER_PAGE && i < state->num_epubs; i++)
+  for (int i = start_index; i < start_index + EPUBS_PER_PAGE && i < state.num_epubs; i++)
   {
     // do we need to draw a new page of items?
-    if (current_page != state->previous_rendered_page)
+    if (current_page != state.previous_rendered_page)
     {
       ESP_LOGI(TAG, "Rendering item %d", i);
-      Epub *epub = new Epub(state->epub_list[i].path);
+      Epub *epub = new Epub(state.epub_list[i].path);
       epub->load();
       // draw the cover page
       int image_xpos = PADDING;
@@ -146,12 +146,12 @@ void EpubList::render()
       free(image_data);
       // draw the title
       int text_xpos = image_xpos + image_width + PADDING;
-      int text_ypos = ypos + PADDING/2;
+      int text_ypos = ypos + PADDING / 2;
       int text_width = renderer->get_page_width() - (text_xpos + PADDING);
       int text_height = cell_height - PADDING * 2;
       // use the text block to layout the title
       TextBlock *title_block = new TextBlock(LEFT_ALIGN);
-      title_block->add_span(state->epub_list[i].title, false, false);
+      title_block->add_span(state.epub_list[i].title, false, false);
       title_block->layout(renderer, epub, text_width);
       // work out the height of the title
       int title_height = title_block->line_breaks.size() * renderer->get_line_height();
@@ -167,7 +167,7 @@ void EpubList::render()
       delete epub;
     }
     // clear the selection box around the previous selected item
-    if (state->previous_selected_item == i)
+    if (state.previous_selected_item == i)
     {
       for (int i = 0; i < 5; i++)
       {
@@ -175,7 +175,7 @@ void EpubList::render()
       }
     }
     // draw the selection box around the current selection
-    if (state->selected_item == i)
+    if (state.selected_item == i)
     {
       for (int i = 0; i < 5; i++)
       {
@@ -184,6 +184,6 @@ void EpubList::render()
     }
     ypos += cell_height;
   }
-  state->previous_selected_item = state->selected_item;
-  state->previous_rendered_page = current_page;
+  state.previous_selected_item = state.selected_item;
+  state.previous_rendered_page = current_page;
 }

--- a/lib/Epub/EpubList/EpubList.h
+++ b/lib/Epub/EpubList/EpubList.h
@@ -11,11 +11,11 @@ class EpubList
 {
 private:
   Renderer *renderer;
-  EpubListState *state;
+  EpubListState &state;
   bool m_needs_redraw = false;
 
 public:
-  EpubList(Renderer *renderer, EpubListState *state) : renderer(renderer), state(state){};
+  EpubList(Renderer *renderer, EpubListState &state) : renderer(renderer), state(state){};
   ~EpubList() {}
   bool load(const char *path);
   void set_needs_redraw() { m_needs_redraw = true; }

--- a/lib/Epub/EpubList/EpubReader.cpp
+++ b/lib/Epub/EpubList/EpubReader.cpp
@@ -96,3 +96,8 @@ void EpubReader::render()
   ESP_LOGD(TAG, "rendered page %d of %d", state.current_page, parser->get_page_count());
   ESP_LOGD(TAG, "after render: %d", esp_get_free_heap_size());
 }
+
+void EpubReader::set_state_section(uint16_t current_section) {
+  ESP_LOGI(TAG, "go to section:%d", current_section);
+  state.current_section = current_section;
+}

--- a/lib/Epub/EpubList/EpubReader.h
+++ b/lib/Epub/EpubList/EpubReader.h
@@ -23,4 +23,5 @@ public:
   void next();
   void prev();
   void render();
+  void set_state_section(uint16_t current_section);
 };

--- a/lib/Epub/EpubList/State.h
+++ b/lib/Epub/EpubList/State.h
@@ -33,6 +33,4 @@ typedef struct
   int previous_rendered_page;
   int previous_selected_item;
   int selected_item;
-  int num_items;
-  bool is_loaded;
 } EpubIndexState;

--- a/lib/Epub/EpubList/State.h
+++ b/lib/Epub/EpubList/State.h
@@ -26,3 +26,13 @@ typedef struct
   bool is_loaded;
   EpubListItem epub_list[MAX_EPUB_LIST_SIZE];
 } EpubListState;
+
+// this is held in the RTC memory
+typedef struct
+{
+  int previous_rendered_page;
+  int previous_selected_item;
+  int selected_item;
+  int num_items;
+  bool is_loaded;
+} EpubIndexState;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -96,14 +96,14 @@ void handleEpubTableContents(Renderer *renderer, UIAction action, bool needs_red
     contents->next();
     break;
   case SELECT:
-    // switch to reading the epub
-    delete contents;
     // setup the reader state
     ui_state = READING_EPUB;
     // create the reader and load the book
     reader = new EpubReader(epub_list_state.epub_list[epub_list_state.selected_item], renderer);
     reader->set_state_section(contents->get_selected_toc());
     reader->load();
+    //switch to reading the epub
+    delete contents;
     handleEpub(renderer, NONE);
     return;
   case NONE:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -102,6 +102,7 @@ void handleEpubTableContents(Renderer *renderer, UIAction action, bool needs_red
     ui_state = READING_EPUB;
     // create the reader and load the book
     reader = new EpubReader(epub_list_state.epub_list[epub_list_state.selected_item], renderer);
+    reader->set_state_section(contents->get_selected_toc());
     reader->load();
     handleEpub(renderer, NONE);
     return;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -87,6 +87,7 @@ void handleEpubTableContents(Renderer *renderer, UIAction action, bool needs_red
   if (!contents)
   {
     contents = new EpubIndex(epub_list_state.epub_list[epub_list_state.selected_item], epub_index_state, renderer);
+    contents->set_needs_redraw();
     contents->load();
   }
   switch (action)
@@ -147,6 +148,7 @@ void handleEpubList(Renderer *renderer, UIAction action, bool needs_redraw)
     // create the reader and load the book
     contents = new EpubIndex(epub_list_state.epub_list[epub_list_state.selected_item], epub_index_state, renderer);
     contents->load();
+    contents->set_needs_redraw();
     handleEpubTableContents(renderer, NONE, true);
     return;
   case NONE:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -36,6 +36,8 @@ typedef enum
 RTC_NOINIT_ATTR UIState ui_state = SELECTING_EPUB;
 // the state data for the epub list and reader
 RTC_DATA_ATTR EpubListState epub_list_state;
+// the state data for the epub index list
+RTC_DATA_ATTR EpubIndexState epub_index_state;
 
 void handleEpub(Renderer *renderer, UIAction action);
 void handleEpubList(Renderer *renderer, UIAction action, bool needs_redraw);
@@ -69,7 +71,7 @@ void handleEpub(Renderer *renderer, UIAction action)
     // force a redraw
     if (!epub_list)
     {
-      epub_list = new EpubList(renderer, &epub_list_state);
+      epub_list = new EpubList(renderer, epub_list_state);
     }
     handleEpubList(renderer, NONE, true);
     return;
@@ -84,7 +86,7 @@ void handleEpubTableContents(Renderer *renderer, UIAction action, bool needs_red
 {
   if (!contents)
   {
-    contents = new EpubIndex(epub_list_state.epub_list[epub_list_state.selected_item], renderer);
+    contents = new EpubIndex(epub_list_state.epub_list[epub_list_state.selected_item], epub_index_state, renderer);
     contents->load();
   }
   switch (action)
@@ -119,7 +121,7 @@ void handleEpubList(Renderer *renderer, UIAction action, bool needs_redraw)
   if (!epub_list)
   {
     ESP_LOGI("main", "Creating epub list");
-    epub_list = new EpubList(renderer, &epub_list_state);
+    epub_list = new EpubList(renderer, epub_list_state);
     if (epub_list->load("/fs/"))
     {
       ESP_LOGI("main", "Epub files loaded");
@@ -143,7 +145,7 @@ void handleEpubList(Renderer *renderer, UIAction action, bool needs_redraw)
     // setup the reader state
     ui_state = SELECTING_TABLE_CONTENTS;
     // create the reader and load the book
-    contents = new EpubIndex(epub_list_state.epub_list[epub_list_state.selected_item], renderer);
+    contents = new EpubIndex(epub_list_state.epub_list[epub_list_state.selected_item], epub_index_state, renderer);
     contents->load();
     handleEpubTableContents(renderer, NONE, true);
     return;

--- a/test/test_epub_index_load.cpp
+++ b/test/test_epub_index_load.cpp
@@ -8,14 +8,14 @@ void test_epub_toc_load(void)
   TEST_ASSERT_TRUE(result);
   TEST_ASSERT_EQUAL(epub->get_toc_items_count(), 12);
   TEST_ASSERT_EQUAL_STRING("The Strange Case Of Dr. Jekyll And Mr. Hyde", epub->get_toc_item(0).title.c_str());
-  TEST_ASSERT_EQUAL_STRING("@public@vhost@g@gutenberg@html@files@43@43-h@43-h-0.htm.html", epub->get_toc_item(0).href.c_str());
+  TEST_ASSERT_EQUAL_STRING("OEBPS/@public@vhost@g@gutenberg@html@files@43@43-h@43-h-0.htm.html", epub->get_toc_item(0).href.c_str());
   TEST_ASSERT_EQUAL_STRING("pgepubid00000", epub->get_toc_item(0).anchor.c_str());
 
   TEST_ASSERT_EQUAL_STRING("Contents", epub->get_toc_item(1).title.c_str());
-  TEST_ASSERT_EQUAL_STRING("@public@vhost@g@gutenberg@html@files@43@43-h@43-h-0.htm.html", epub->get_toc_item(1).href.c_str());
+  TEST_ASSERT_EQUAL_STRING("OEBPS/@public@vhost@g@gutenberg@html@files@43@43-h@43-h-0.htm.html", epub->get_toc_item(1).href.c_str());
   TEST_ASSERT_EQUAL_STRING("pgepubid00001", epub->get_toc_item(1).anchor.c_str());
 
   TEST_ASSERT_EQUAL_STRING("HENRY JEKYLL\xE2\x80\x99S FULL STATEMENT OF THE CASE", epub->get_toc_item(11).title.c_str());
-  TEST_ASSERT_EQUAL_STRING("@public@vhost@g@gutenberg@html@files@43@43-h@43-h-10.htm.html", epub->get_toc_item(11).href.c_str());
+  TEST_ASSERT_EQUAL_STRING("OEBPS/@public@vhost@g@gutenberg@html@files@43@43-h@43-h-10.htm.html", epub->get_toc_item(11).href.c_str());
   TEST_ASSERT_EQUAL_STRING("pgepubid00011", epub->get_toc_item(11).anchor.c_str());
 }

--- a/test/test_epub_index_load.cpp
+++ b/test/test_epub_index_load.cpp
@@ -1,16 +1,21 @@
 #include <unity.h>
 #include <EpubList/Epub.h>
 
-void test_epub_index_load(void)
+void test_epub_toc_load(void)
 {
   Epub *epub = new Epub("fixtures/oebps.epub");
-  bool result = epub->loadIndex();
+  bool result = epub->load();
   TEST_ASSERT_TRUE(result);
-  TEST_ASSERT_EQUAL(epub->toc_index.size(), 12);
-  TEST_ASSERT_EQUAL_STRING(epub->toc_index[0].first.c_str(), "The Strange Case Of Dr. Jekyll And Mr. Hyde");
-  TEST_ASSERT_EQUAL_STRING(epub->toc_index[0].second.c_str(), "@public@vhost@g@gutenberg@html@files@43@43-h@43-h-0.htm.html#pgepubid00000");
-  TEST_ASSERT_EQUAL_STRING(epub->toc_index[1].first.c_str(), "Contents");
-  TEST_ASSERT_EQUAL_STRING(epub->toc_index[1].second.c_str(), "@public@vhost@g@gutenberg@html@files@43@43-h@43-h-0.htm.html#pgepubid00001");
-  TEST_ASSERT_EQUAL_STRING(epub->toc_index[11].first.c_str(), "INCIDENT OF THE LETTER");
-  TEST_ASSERT_EQUAL_STRING(epub->toc_index[11].second.c_str(), "@public@vhost@g@gutenberg@html@files@43@43-h@43-h-5.htm.html#pgepubid00006");
+  TEST_ASSERT_EQUAL(epub->get_toc_items_count(), 12);
+  TEST_ASSERT_EQUAL_STRING("The Strange Case Of Dr. Jekyll And Mr. Hyde", epub->get_toc_item(0).title.c_str());
+  TEST_ASSERT_EQUAL_STRING("@public@vhost@g@gutenberg@html@files@43@43-h@43-h-0.htm.html", epub->get_toc_item(0).href.c_str());
+  TEST_ASSERT_EQUAL_STRING("pgepubid00000", epub->get_toc_item(0).anchor.c_str());
+
+  TEST_ASSERT_EQUAL_STRING("Contents", epub->get_toc_item(1).title.c_str());
+  TEST_ASSERT_EQUAL_STRING("@public@vhost@g@gutenberg@html@files@43@43-h@43-h-0.htm.html", epub->get_toc_item(1).href.c_str());
+  TEST_ASSERT_EQUAL_STRING("pgepubid00001", epub->get_toc_item(1).anchor.c_str());
+
+  TEST_ASSERT_EQUAL_STRING("HENRY JEKYLL\xE2\x80\x99S FULL STATEMENT OF THE CASE", epub->get_toc_item(11).title.c_str());
+  TEST_ASSERT_EQUAL_STRING("@public@vhost@g@gutenberg@html@files@43@43-h@43-h-10.htm.html", epub->get_toc_item(11).href.c_str());
+  TEST_ASSERT_EQUAL_STRING("pgepubid00011", epub->get_toc_item(11).anchor.c_str());
 }

--- a/test/test_epub_index_load.cpp
+++ b/test/test_epub_index_load.cpp
@@ -1,0 +1,16 @@
+#include <unity.h>
+#include <EpubList/Epub.h>
+
+void test_epub_index_load(void)
+{
+  Epub *epub = new Epub("fixtures/oebps.epub");
+  bool result = epub->loadIndex();
+  TEST_ASSERT_TRUE(result);
+  TEST_ASSERT_EQUAL(epub->toc_index.size(), 12);
+  TEST_ASSERT_EQUAL_STRING(epub->toc_index[0].first.c_str(), "The Strange Case Of Dr. Jekyll And Mr. Hyde");
+  TEST_ASSERT_EQUAL_STRING(epub->toc_index[0].second.c_str(), "@public@vhost@g@gutenberg@html@files@43@43-h@43-h-0.htm.html#pgepubid00000");
+  TEST_ASSERT_EQUAL_STRING(epub->toc_index[1].first.c_str(), "Contents");
+  TEST_ASSERT_EQUAL_STRING(epub->toc_index[1].second.c_str(), "@public@vhost@g@gutenberg@html@files@43@43-h@43-h-0.htm.html#pgepubid00001");
+  TEST_ASSERT_EQUAL_STRING(epub->toc_index[11].first.c_str(), "INCIDENT OF THE LETTER");
+  TEST_ASSERT_EQUAL_STRING(epub->toc_index[11].second.c_str(), "@public@vhost@g@gutenberg@html@files@43@43-h@43-h-5.htm.html#pgepubid00006");
+}

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -6,6 +6,7 @@ void test_epub_no_oebps_load(void);
 void test_epub_load(void);
 void test_epub_relative_image_paths(void);
 void test_html_entity_replacement(void);
+void test_epub_index_load(void);
 
 int main(int argc, char **argv)
 {
@@ -16,6 +17,7 @@ int main(int argc, char **argv)
   RUN_TEST(test_epub_load);
   RUN_TEST(test_epub_relative_image_paths);
   RUN_TEST(test_html_entity_replacement);
+  RUN_TEST(test_epub_index_load);
   UNITY_END();
 
   return 0;

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -6,7 +6,7 @@ void test_epub_no_oebps_load(void);
 void test_epub_load(void);
 void test_epub_relative_image_paths(void);
 void test_html_entity_replacement(void);
-void test_epub_index_load(void);
+void test_epub_toc_load(void);
 
 int main(int argc, char **argv)
 {
@@ -17,7 +17,7 @@ int main(int argc, char **argv)
   RUN_TEST(test_epub_load);
   RUN_TEST(test_epub_relative_image_paths);
   RUN_TEST(test_html_entity_replacement);
-  RUN_TEST(test_epub_index_load);
+  RUN_TEST(test_epub_toc_load);
   UNITY_END();
 
   return 0;


### PR DESCRIPTION
First draft to parse the content's index.  @cgreening I will need some help with this one since I don't understand completely the whole structure yet. Started only with the parsing the toc.ncx file 
This is what it outputs via Serial for the ww2 book:

```
ncx in line:4
I (17758) EPUB: title Cubierta src Text/cubierta.xhtml
I (17758) EPUB: title Pequeñas grandes historias de la Segunda Guerra Mundial src Text/titulo.xhtml
I (17768) EPUB: title Introducción src Text/Introduccion.xhtml
I (17768) EPUB: title 1. Los primeros src Text/Capitulo1.xhtml
I (17778) EPUB: title 2. En la retaguardia src Text/Capitulo2.xhtml
I (17788) EPUB: title 3. El esfuerzo de guerra src Text/Capitulo3.xhtml
I (17788) EPUB: title 4. En el aire src Text/Capitulo4.xhtml
I (17798) EPUB: title 5. En el mar src Text/Capitulo5.xhtml
I (17808) EPUB: title 6. La tragedia de la guerra src Text/Capitulo6.xhtml
I (17808) EPUB: title 7. En la línea de fuego src Text/Capitulo7.xhtml
I (17818) EPUB: title 8. Los otros protagonistas src Text/Capitulo8.xhtml
I (17828) EPUB: title 9. Historias de ingenio src Text/Capitulo9.xhtml
I (17838) EPUB: title 10. Hechos insólitos src Text/Capitulo10.xhtml
I (17838) EPUB: title 11. Los últimos src Text/Capitulo11.xhtml
I (17848) EPUB: title Apéndice src Text/Apendice.xhtml
I (17858) EPUB: title Bibliografía src Text/Bibliografia.xhtml
I (17858) EPUB: title Autor src Text/autor.xhtml
I (17868) EPUB: title Notas src Text/notas.xhtm
```

Question do we need to take this *.ncx name from the manifest or it will be faster just to open the first OEBPS filename.ncx (So far all have the ncx extension sometimes with different filename)
I would go for the fastest option if possible. 