### PR TITLE
Make the debounce longer - was getting false clicks on the M5Paper

### DIFF
--- a/src/boards/controls/GPIOButton.cpp
+++ b/src/boards/controls/GPIOButton.cpp
@@ -3,7 +3,7 @@
 #include <driver/gpio.h>
 
 // 100 ms debounce on the buttons
-const int BUTTON_DEBOUNCE = 1000;
+const int BUTTON_DEBOUNCE = 50000;
 
 IRAM_ATTR void button_interrupt_handler(void *param)
 {


### PR DESCRIPTION
I was seeing lots of fake clicks on the M5Paper - this seems to be more robust