### PR TITLE
Remove unused docTitle extraction

### DIFF
--- a/lib/Epub/EpubList/Epub.cpp
+++ b/lib/Epub/EpubList/Epub.cpp
@@ -202,13 +202,6 @@ bool Epub::parse_toc_ncx_file(ZipFile &zip)
     return false;
   }
 
-  auto docTitle = ncx->FirstChildElement("docTitle");
-  if (!docTitle)
-  {
-    ESP_LOGE(TAG, "Could not find docTitle child in ncx");
-    return false;
-  }
-
   auto navMap = ncx->FirstChildElement("navMap");
   if (!navMap)
   {


### PR DESCRIPTION
I have some ebooks that do not have the `docTitle` property which causes them not to load. I noticed this isn't actually being used for anything so this PR removes it.

I appreciate this is a bit of a brute-force solution so if you have a preference to this remaining, I'm all ears!