### PR TITLE
Fixed Espressif to 3.3.2 and reduced environments with heredity

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -12,20 +12,17 @@
 ; lilygo_t5_47 | epdiy | native | m5_paper
 default_envs = lilygo_t5_47
 
-[env:lilygo_t5_47]
-platform = espressif32
-board = esp32dev
+[common]
+platform = espressif32 @ 3.3.2
 framework = espidf
+board = esp32dev
 ;upload_port = /dev/cu.SLAB_USBtoUART 
 ;monitor_port = /dev/cu.SLAB_USBtoUART
 monitor_speed = 115200
 monitor_filters = esp32_exception_decoder
-board_build.partitions = partitions.csv
 lib_deps =
   https://github.com/leethomason/tinyxml2.git
 build_flags =
-  ; Based on the EPDIY with some minor changes 
-  -DBOARD_TYPE_LILIGO_T5_47
   ; maximim speed
   -Ofast
   ; needed to stop the png library tying to pull in Arduino.h
@@ -35,6 +32,29 @@ build_flags =
   ; device has PRSRAM
   ; and should be used for ram intensive display work
   -DBOARD_HAS_PSRAM
+  ; Logging. Leave enabled for first builds and debugging. Comment to disable
+  -D LOG_ENABLED
+ 
+
+[esp32_common]
+platform = ${common.platform}
+framework = ${common.framework}
+board = ${common.board}
+;upload_port = ${common.upload_port}
+;monitor_port = ${common.monitor_port}
+monitor_speed = ${common.monitor_speed}
+monitor_filters = ${common.monitor_filters}
+build_flags = ${common.build_flags}
+lib_deps = ${common.lib_deps}
+board_build.partitions = partitions.csv
+
+
+[env:lilygo_t5_47]
+extends = esp32_common
+build_flags =
+  ${common.build_flags}
+  ; Based on the EPDIY with some minor changes 
+  -DBOARD_TYPE_LILIGO_T5_47  
   ; Setup display format and model via build flags
   -DCONFIG_EPD_DISPLAY_TYPE_ED047TC2
   -DCONFIG_EPD_BOARD_REVISION_LILYGO_T5_47
@@ -46,10 +66,7 @@ build_flags =
   ; the adc channel that is connected to the battery voltage divider - this is GPIO_NUM_36
   -DBATTERY_ADC_CHANNEL=ADC1_CHANNEL_0
   ; use SPIFFS - experimental feature
-  -D USE_SPIFFS
-  
-  ; Logging. Leave enabled for first builds and debugging. Comment to disable
-  -D LOG_ENABLED
+  -D USE_SPIFFS 
   ; Touch configuration
   -D USE_L58_TOUCH
   -D CONFIG_TOUCH_SDA=15
@@ -59,26 +76,11 @@ build_flags =
   -D CONFIG_FT6X36_DEBUG=0
 
 [env:epdiy]
-platform = espressif32
-board = esp32dev
-framework = espidf
-monitor_speed = 115200
-monitor_filters = esp32_exception_decoder
-board_build.partitions = partitions.csv
-lib_deps =
-  https://github.com/leethomason/tinyxml2.git
+extends = esp32_common
 build_flags =
+  ${common.build_flags}
   ; It's an EPDIY board
   -DBOARD_TYPE_EPDIY
-  ; maximim speed
-  -Ofast
-  ; needed to stop the png library tying to pull in Arduino.h
-  -D __MCUXPRESSO
-  ; stop miniz conflicting with zlib which is used by the png library
-  -D MINIZ_NO_ZLIB_COMPATIBLE_NAMES
-  ; device has PRSRAM
-  ; and should be used for ram intensive display work
-  -D BOARD_HAS_PSRAM
   ; Setup display format and model via build flags
   -D CONFIG_EPD_DISPLAY_TYPE_ED060XC3
   -D CONFIG_EPD_BOARD_REVISION_V6
@@ -96,8 +98,6 @@ build_flags =
   ; Commenting this it will not show the battery level indicator
   -D BATTERY_ADC_CHANNEL=ADC1_CHANNEL_6
   
-  ; Logging. Leave enabled for first builds and debugging. Comment to disable
-  -D LOG_ENABLED
   ; Touch configuration
   ; V6: Disable touch for this test and update Board
   ;-D USE_L58_TOUCH
@@ -112,28 +112,11 @@ lib_ignore =
 
 
 [env:m5_paper]
-platform = espressif32
-board = esp32dev
-framework = espidf
-;upload_port = /dev/cu.SLAB_USBtoUART 
-;monitor_port = /dev/cu.SLAB_USBtoUART
-monitor_speed = 115200
-monitor_filters = esp32_exception_decoder
-board_build.partitions = partitions.csv
-lib_deps =
-  https://github.com/leethomason/tinyxml2.git
+extends = esp32_common
 build_flags =
+  ${common.build_flags}
   ; This is an M5 EPD display
   -DBOARD_TYPE_M5_PAPER
-  ; maximim speed
-  -Ofast
-  ; needed to stop the png library tying to pull in Arduino.h
-  -D__MCUXPRESSO
-  ; stop miniz conflicting with zlib which is used by the png library
-  -DMINIZ_NO_ZLIB_COMPATIBLE_NAMES
-  ; device has PRSRAM
-  ; and should be used for ram intensive display work
-  -DBOARD_HAS_PSRAM
   ; Setup display format and model via build flags - we're only using part of the epdiy codebase
   ; mainly the drawing code - but these settings will get us to compile and give us the correct 
   ; display size
@@ -148,8 +131,6 @@ build_flags =
   -DBATTERY_ADC_CHANNEL=ADC1_CHANNEL_7
   ; use SPIFFS - experimental feature
   ;-D USE_SPIFFS
-  ; Logging. Leave enabled for first builds and debugging. Comment to disable
-  -D LOG_ENABLED
 lib_ignore = 
   touch
   FT6X36


### PR DESCRIPTION
## Summary

- [x] Fixed Espressif version to 3.3.2 (suggested on WiKi and possible issue with current master)
- [x] Improved PlatformIO ini file with some reductions using Pio env heredity

## Hardware tests

- [x] Tested on m5paper

## Compiling tests

All environment pass ok. Setup details:

```python
PLATFORM: Espressif 32 (3.3.2) > Espressif ESP32 Dev Module
HARDWARE: ESP32 240MHz, 320KB RAM, 4MB Flash
PACKAGES: framework-espidf @ 3.40300.0 (4.3.0)
``` 